### PR TITLE
Compatibility with couchdb3

### DIFF
--- a/check_couchdb_replication.sh
+++ b/check_couchdb_replication.sh
@@ -175,7 +175,7 @@ else
   elif [[ -n $(echo $cdbresp | grep -i "You are not a server admin") ]]; then
     echo "COUCHDB REPLICATION CRITICAL - You are not a server admin"
     exit $STATE_CRITICAL
-  elif [[ -n $(echo $cdbresp | grep -i missing) ]]; then
+  elif [[ -n $(echo $cdbresp | grep -i '"reason":"missing"') ]]; then
     echo "COUCHDB REPLICATION CRITICAL - Replication for $repid not found"
     exit $STATE_CRITICAL
   elif [[ -z $cdbresp ]]; then


### PR DESCRIPTION
In couchdb 3 (at least 3.1.1), the chain "missing" is found in a good output, because of "missing_revisions_found" variable:

```
# curl -k -s http://localhost:5984/_scheduler/docs/_replicator/REPLICATION_PROD
{"database":"_replicator","doc_id":"REPLICATION_PROD","id":"...","node":"couchdb@127.0.0.1","source":"http://10.20.44.2:5984/.../","target":"http://localhost:5984/.../","state":"running","info":{"revisions_checked":20836,"missing_revisions_found":0,"docs_read":0,"docs_written":0,"changes_pending":0,"doc_write_failures":0,"checkpointed_source_seq":"…}
```

As you can see, this makes the script return  `Replication REPLICATION_PROD not found`. This PR fixes this problem, and stays compatible with couchdb 2 replication.

Thank you for this script.