### PR TITLE
Rewrite script, several improvements

### DIFF
--- a/check_couchdb_replication.sh
+++ b/check_couchdb_replication.sh
@@ -22,7 +22,6 @@
 # 02110-1301, USA.                                                             #
 #                                                                              #
 # (c) 2018, 2022 Claudio Kuenzler                                              #
-# (c) 2021 Guillaume Subiron                                                   #
 #                                                                              #
 # History:                                                                     #
 # 20180105: Created plugin                                                     #
@@ -32,7 +31,6 @@
 # 20180326: Avoid confusion about wrong credentials (issue 4)                  #
 # 20180326: Add possibility to check all replications at once (-r ALL)         #
 # 20180326: Handle authentication error "You are not a server admin."          #
-# 20220221: Compatibility with CouchDB 3 (PR #6 from April 2021)               #
 # 20220221: Replace jshon with jq                                              #
 # 20220221: Improve output of detected replications                            #
 # 20220222: Handle "One Time" replications, add -i parameter (issue #5)        #

--- a/check_couchdb_replication.sh
+++ b/check_couchdb_replication.sh
@@ -65,7 +65,7 @@ Options:
      -h Help!
 
 *-H is mandatory for all ways of running the script
-**-r is mandatory to check a defined replication (doc_id) 
+**-r is mandatory to check a defined replication (doc_id or ALL)
 **-d is mandatory if no replication check (-r) is set
 
 Requirements: curl, jq, tr"

--- a/check_couchdb_replication.sh
+++ b/check_couchdb_replication.sh
@@ -35,6 +35,8 @@
 # 20220221: Compatibility with CouchDB 3 (PR #6 from April 2021)               #
 # 20220221: Replace jshon with jq                                              #
 # 20220221: Improve output of detected replications                            #
+# 20220222: Handle "One Time" replications, add -i parameter (issue #5)        #
+# 20220222: Improve all HTTP requests with a dedicated function                #
 ################################################################################
 #Variables and defaults
 STATE_OK=0              # define the exit code if status is OK
@@ -44,10 +46,11 @@ STATE_UNKNOWN=3         # define the exit code if status is Unknown
 export PATH=$PATH:/usr/local/bin:/usr/bin:/bin # Set path
 port=5984
 protocol=http
+ignore_one_time=true
 ################################################################################
 #Functions
 help () {
-echo -e "$0  (c) 2018-$(date +%Y) Claudio Kuenzler (published under GPL licence)
+echo -e "$0  (c) 2018-$(date +%Y) Claudio Kuenzler et al (published under GPL licence)
 
 Usage: ./check_couchdb_replication.sh -H MyCouchDBHost [-P port] [-S] [-u user] [-p pass] (-r replication|-d)
 
@@ -58,8 +61,9 @@ Options:
      -S Use https
      -u Username if authentication is required
      -p Password if authentication is required
-  ** -r Replication ID to monitor (doc_id)
+  ** -r Replication ID to monitor (doc_id) or use 'ALL' for all replications
   ** -d Dynamically detect and list all available replications
+     -i Include 'One time' replications in alerting
      -h Help!
 
 *-H is mandatory for all ways of running the script
@@ -76,6 +80,34 @@ elif [[ -n $user ]] && [[ -z $pass ]]; then echo "COUCHDB REPLICATION UNKNOWN - 
 elif [[ -n $pass ]] && [[ -z $user ]]; then echo "COUCHDB REPLICATION UNKNOWN - Missing username"; exit $STATE_UNKNOWN
 fi
 }
+
+httpget() {
+  url=$1
+
+  if [[ -n $user && -n $pass ]]
+    then authlogic; cdburl="${protocol}://${user}:${pass}@${host}:${port}${url}"
+    else cdburl="${protocol}://${host}:${port}${url}"
+  fi
+  cdbresp=$(curl -k -s $cdburl)
+
+  if [[ -n $(echo $cdbresp | grep -i "Name or password is incorrect") ]]; then
+    echo "COUCHDB REPLICATION CRITICAL - Unable to authenticate user $user"
+    exit $STATE_CRITICAL
+  elif [[ -n $(echo $cdbresp | grep -i "401 Authorization Required") ]]; then
+    echo "COUCHDB REPLICATION CRITICAL - Unable to authenticate user $user"
+    exit $STATE_CRITICAL
+  elif [[ -n $(echo $cdbresp | grep -i "You are not a server admin") ]]; then
+    echo "COUCHDB REPLICATION CRITICAL - You are not a server admin"
+    exit $STATE_CRITICAL
+  elif [[ -n $(echo $cdbresp | grep -i '"error":"not_found"') ]]; then
+    echo "COUCHDB REPLICATION CRITICAL - Unable to find replication ($url)"
+    exit $STATE_CRITICAL
+  elif [[ -z $cdbresp ]]; then
+    echo "COUCHDB REPLICATION CRITICAL - Unable to connect to CouchDB on ${protocol}://${host}:${port}"
+    exit $STATE_CRITICAL
+  fi
+
+}
 ################################################################################
 # Check requirements
 for cmd in curl jq tr awk; do
@@ -89,7 +121,7 @@ done
 if [ "${1}" = "--help" -o "${#}" = "0" ]; then help; exit $STATE_UNKNOWN; fi
 ################################################################################
 # Get user-given variables
-while getopts "H:P:Su:p:r:d" Input;
+while getopts "H:P:Su:p:r:di" Input;
 do
   case ${Input} in
   H)      host=${OPTARG};;
@@ -99,6 +131,7 @@ do
   p)      pass=${OPTARG};;
   r)      repid=${OPTARG};;
   d)      detect=1;;
+  i)      ignore_one_time=false;;
   *)      help;;
   esac
 done
@@ -109,23 +142,7 @@ if [ -z ${detect} ] && [ -z ${repid} ]; then help; exit $STATE_UNKNOWN; fi
 ################################################################################
 # If -d (detection) is used, present list of replications
 if [[ ${detect} -eq 1 ]]; then
-  if [[ -n $user && -n $pass ]]
-    then authlogic; cdburl="${protocol}://${user}:${pass}@${host}:${port}/_active_tasks"
-    else cdburl="${protocol}://${host}:${port}/_active_tasks"
-  fi
-  cdbresp=$(curl -k -s $cdburl)
-
-  if [[ -n $(echo $cdbresp | grep -i "Name or password is incorrect") ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - Unable to authenticate user $user"
-    exit $STATE_CRITICAL
-  elif [[ -n $(echo $cdbresp | grep -i "You are not a server admin") ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - You are not a server admin"
-    exit $STATE_CRITICAL
-  elif [[ -z $cdbresp ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - Unable to connect to CouchDB on ${protocol}://${host}:${port}"
-    exit $STATE_CRITICAL
-  fi
-
+  httpget "/_active_tasks"
   replist=$(echo $cdbresp | jq -r '.[] | {doc_id, source} | join (" ")' | while read docid source; do echo "${docid} (${source})"; done | tr "\n" " ")
   if [[ -n $replist ]]; then
     
@@ -138,61 +155,45 @@ if [[ ${detect} -eq 1 ]]; then
 fi
 
 # Do the replication check for all replications
-if [[ "${repid}" == "ALL" ]]
-then 
-  if [[ -n $user && -n $pass ]]
-    then authlogic; cdburl="${protocol}://${user}:${pass}@${host}:${port}/_scheduler/docs/_replicator"
-    else cdburl="${protocol}://${host}:${port}/_scheduler/docs/_replicator"
+if [[ "${repid}" == "ALL" ]]; then
+  httpget "/_scheduler/docs/_replicator"
+
+  # Create stats array from response
+  declare -a successrepls=( $(echo "$cdbresp" | jq -r '.docs[] | select(.state == "running").doc_id') )
+  declare -a failedrepls=( $(echo "$cdbresp" | jq -r '.docs[] | select(.state != "running").doc_id') )
+  declare -a error_count=( $(echo "$cdbresp" | jq -r '.docs[] | select(.state != "running").error_count') )
+  declare -a state=( $(echo "$cdbresp" | jq -r '.docs[] | select(.state != "running").state') )
+
+  if [[ ${#failedrepls[*]} -gt 0 ]]; then
+    declare -a failedinfo=("")
+    r=0
+    for docid in ${failedrepls[*]}; do
+	    #echo "Handling $docid" # Debug
+	    if [[ $ignore_one_time == true ]]; then
+	      httpget "/_replicator/${docid}"
+	      continuous=$(echo "$cdbresp" | jq -r '.continuous' )
+	      if [[ ${continuous} == false ]]; then
+		      unset "failedrepls[${r}]"
+	      fi
+	    fi
+	    failedinfo[${r}]="${docid} (state: ${state[${r}]}, error count: ${error_count[${r}]}) "
+	    let r++
+    done
   fi
-  cdbresp=$(curl -k -s $cdburl)
 
-  if [[ -n $(echo $cdbresp | grep -i "Name or password is incorrect") ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - Unable to authenticate user $user"
+  if [[ ${#failedrepls[*]} -gt 0 ]]; then
+    echo "COUCHDB REPLICATION CRITICAL: ${#failedrepls[*]} continuous replications not running - Details: ${failedinfo[*]}"
     exit $STATE_CRITICAL
-  elif [[ -n $(echo $cdbresp | grep -i "You are not a server admin") ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - You are not a server admin"
-    exit $STATE_CRITICAL
-  fi
-
-  # Count failed replications
-  failedrepls=$(echo "$cdbresp"| grep database | grep -v '"state":"running"')
-  failedcount=$(echo "$failedrepls" | wc -l)
-
-  if [[ ${failedcount} -gt 0 ]] && [[ ${failedrepls} =~ "database" ]]
-  then 
-    failedinfo=$(echo "$failedrepls" | awk -F',' '{print $2" "$7" "$8}' | tr "\n" ",")
-    #echo "COUCHDB REPLICATION CRITICAL - ${failedcount} replications not running" $cdbresp"| grep database | grep -v '"state":"running"' | awk -F',' '{print $2" "$7" "$8}' | tr "\n" ","
-    echo "COUCHDB REPLICATION CRITICAL - ${failedcount} replications not running ($failedinfo)" 
-    exit $STATE_CRITICAL
-  else 
-    echo "COUCHDB REPLICATION OK - All replications running"; exit $STATE_OK
+  else
+    echo "COUCHDB REPLICATION OK - All ${#successrepls[*]} continuous replications running"; exit $STATE_OK
   fi
 
 else
   # Do the replication check for a single replication
-  if [[ -n $user && -n $pass ]]
-    then authlogic; cdburl="${protocol}://${user}:${pass}@${host}:${port}/_scheduler/docs/_replicator/${repid}"
-    else cdburl="${protocol}://${host}:${port}/_scheduler/docs/_replicator/${repid}"
-  fi
-  cdbresp=$(curl -k -s $cdburl)
-  
-  if [[ -n $(echo $cdbresp | grep -i "Name or password is incorrect") ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - Unable to authenticate user $user"
-    exit $STATE_CRITICAL
-  elif [[ -n $(echo $cdbresp | grep -i "You are not a server admin") ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - You are not a server admin"
-    exit $STATE_CRITICAL
-  elif [[ -n $(echo $cdbresp | grep -i '"reason":"missing"') ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - Replication for $repid not found"
-    exit $STATE_CRITICAL
-  elif [[ -z $cdbresp ]]; then
-    echo "COUCHDB REPLICATION CRITICAL - Unable to connect to CouchDB on ${protocol}://${host}:${port}"
-    exit $STATE_CRITICAL
-  fi
-  
+  httpget "/_scheduler/docs/_replicator/${repid}"
   repstatus=$(echo $cdbresp | jq -r '.state')
   
-  if [[ "$repstatus" == '"running"' ]]; then
+  if [[ "$repstatus" == "running" ]]; then
     echo "COUCHDB REPLICATION OK - Replication $repid is $repstatus"
     exit $STATE_OK
   else 


### PR DESCRIPTION
This new version (20220222 - look at that date!) is a major rewrite of the plugin. 

- The HTTP requests are now used in a separate function. Code should be easier to read and understand this way. HTTP response handling is now handled within that function.
- Improved output of `-d` (detect replications). Besides the doc_id, the source is now also showing. This could help to identify the replication you really want to focus on.
- Ignoring non-continuous (one time) replications in the replication check by default. Added the new optional parameter `-i` to include one time replications. Fixes #5 
- Replaced `jshon` with `jq` command. This is a change in plugin requirement.
- Several other minor improvements